### PR TITLE
Add flexbox to sass styles

### DIFF
--- a/dev/sass/classes/display.scss
+++ b/dev/sass/classes/display.scss
@@ -11,4 +11,5 @@
   &--table-cell   { display: table-cell; }
   &--table-column { display: table-column; }
   &--table-row    { display: table-row; }
+  &--flex         { display: flex;  }
 }

--- a/dev/sass/styles.scss
+++ b/dev/sass/styles.scss
@@ -59,6 +59,7 @@
 @import "classes/clear";
 @import "classes/cursor";
 @import "classes/display";
+@import "classes/flexbox";
 @import "classes/float";
 @import "classes/font-style";
 @import "classes/font-weight";


### PR DESCRIPTION
Added flexbox styles to Sass, excepting the `.flex` shorthand property, which may require some deeper thought and planning.